### PR TITLE
Fix for Undo stacks beyond a single iteration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,22 @@ userListCopy.apply(patchCopy);
 userListCopy.head.get('3').should.be.exactly(dan);
 
 // It's possible to implement an undo stack by reverting patches
-const revert = Patch.revert(patch);
-userListCopy.apply(revert);
-userListCopy.head.has('3').should.be.exactly(false);
-userListCopy.head.contains(dan).should.be.exactly(false);
-userListCopy.head.contains(isaac).should.be.exactly(true);
+userListCopy.set('4', bard);
+const patch1 = userListCopy.commit();
+userListCopy.set('5', manu);
+const patch2 = userListCopy.commit();
+userListCopy.head.has('5').should.be.exactly(true);
+userListCopy.head.contains(manu).should.be.exactly(true);
+const revert2 = Patch.revert(patch2);
+userListCopy.apply(revert2);
+userListCopy.head.has('4').should.be.exactly(true);
+userListCopy.head.has('5').should.be.exactly(false);
+userListCopy.head.contains(bard).should.be.exactly(true);
+userListCopy.head.contains(manu).should.be.exactly(false);
+const revert1 = Patch.revert(patch1);
+userListCopy.apply(revert1);
+userListCopy.head.has('4').should.be.exactly(false);
+userListCopy.head.contains(bard).should.be.exactly(false);
 
 // Several small patches can be combined into a bigger one
 const userListCopy2 = Remutable.fromJSON(userList.toJSON());

--- a/dist/Patch.js
+++ b/dist/Patch.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var _prototypeProperties = function (child, staticProps, instanceProps) { if (staticProps) Object.defineProperties(child, staticProps); if (instanceProps) Object.defineProperties(child.prototype, instanceProps); };
+var _createClass = (function () { function defineProperties(target, props) { for (var key in props) { var prop = props[key]; prop.configurable = true; if (prop.value) prop.writable = true; } Object.defineProperties(target, props); } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
 
 var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } };
 
@@ -22,6 +22,7 @@ module.exports = function (Remutable) {
       var mutations = _ref.mutations;
       var from = _ref.from;
       var to = _ref.to;
+
       _classCallCheck(this, Patch);
 
       if (__DEV__) {
@@ -42,7 +43,37 @@ module.exports = function (Remutable) {
       _.bindAll(this, ["toJS", "toJSON"]);
     }
 
-    _prototypeProperties(Patch, {
+    _createClass(Patch, {
+      source: {
+        get: function () {
+          return this.from.h;
+        }
+      },
+      target: {
+        get: function () {
+          return this.to.h;
+        }
+      },
+      toJS: {
+        value: function toJS() {
+          if (this._js === null) {
+            this._js = {
+              m: this.mutations,
+              f: this.from,
+              t: this.to };
+          }
+          return this._js;
+        }
+      },
+      toJSON: {
+        value: function toJSON() {
+          if (this._json === null) {
+            this._json = JSON.stringify(this.toJS());
+          }
+          return this._json;
+        }
+      }
+    }, {
       revert: {
         value: function revert(patch) {
           var mutations = {};
@@ -50,48 +81,47 @@ module.exports = function (Remutable) {
             var _patch$mutations$key = patch.mutations[key];
             var f = _patch$mutations$key.f;
             var t = _patch$mutations$key.t;
+
             mutations[key] = { f: t, t: f };
           });
-          return Patch.fromMutations({ mutations: mutations, hash: patch.to.h, version: patch.to.v });
-        },
-        writable: true,
-        configurable: true
+          return new Patch({
+            mutations: mutations,
+            from: { h: patch.to.h, v: patch.to.v },
+            to: { h: patch.from.h, v: patch.from.v }
+          });
+        }
       },
       fromMutations: {
         value: function fromMutations(_ref) {
           var mutations = _ref.mutations;
           var hash = _ref.hash;
           var version = _ref.version;
+
           var from = { h: hash, v: version };
           // New hash is calculated so that if two identical remutables are updated
           // using structurally equal mutations, then they will get the same hash.
           var to = { h: Remutable.hashFn(hash + Remutable.signFn(mutations)), v: version + 1 };
           return new Patch({ mutations: mutations, from: from, to: to });
-        },
-        writable: true,
-        configurable: true
+        }
       },
       fromJS: {
         value: function fromJS(_ref) {
           var m = _ref.m;
           var f = _ref.f;
           var t = _ref.t;
+
           if (__DEV__) {
             m.should.be.an.Object;
             f.should.be.an.Object;
             t.should.be.an.Object;
           }
           return new Patch({ mutations: m, from: f, to: t });
-        },
-        writable: true,
-        configurable: true
+        }
       },
       fromJSON: {
         value: function fromJSON(json) {
           return Patch.fromJS(JSON.parse(json));
-        },
-        writable: true,
-        configurable: true
+        }
       },
       combine: {
         value: function combine(patchA, patchB) {
@@ -105,9 +135,7 @@ module.exports = function (Remutable) {
             mutations: _.extend(_.clone(patchA.mutations), patchB.mutations),
             from: _.clone(patchA.from),
             to: _.clone(patchB.to) });
-        },
-        writable: true,
-        configurable: true
+        }
       },
       fromDiff: {
         value: function fromDiff(prev, next) {
@@ -133,45 +161,7 @@ module.exports = function (Remutable) {
             return mutations[key] = { f: prev.head.get(key), t: next.head.get(key) };
           });
           return new Patch({ mutations: mutations, from: from, to: to });
-        },
-        writable: true,
-        configurable: true
-      }
-    }, {
-      source: {
-        get: function () {
-          return this.from.h;
-        },
-        configurable: true
-      },
-      target: {
-        get: function () {
-          return this.to.h;
-        },
-        configurable: true
-      },
-      toJS: {
-        value: function toJS() {
-          if (this._js === null) {
-            this._js = {
-              m: this.mutations,
-              f: this.from,
-              t: this.to };
-          }
-          return this._js;
-        },
-        writable: true,
-        configurable: true
-      },
-      toJSON: {
-        value: function toJSON() {
-          if (this._json === null) {
-            this._json = JSON.stringify(this.toJS());
-          }
-          return this._json;
-        },
-        writable: true,
-        configurable: true
+        }
       }
     });
 

--- a/dist/Remutable.js
+++ b/dist/Remutable.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var _prototypeProperties = function (child, staticProps, instanceProps) { if (staticProps) Object.defineProperties(child, staticProps); if (instanceProps) Object.defineProperties(child.prototype, instanceProps); };
+var _createClass = (function () { function defineProperties(target, props) { for (var key in props) { var prop = props[key]; prop.configurable = true; if (prop.value) prop.writable = true; } Object.defineProperties(target, props); } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
 
 var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } };
 
@@ -25,6 +25,7 @@ var _Remutable = undefined;
 
 var Consumer = function Consumer(ctx) {
   var _this = this;
+
   _classCallCheck(this, Consumer);
 
   if (__DEV__) {
@@ -48,6 +49,7 @@ var Consumer = function Consumer(ctx) {
 var Producer = (function () {
   function Producer(ctx) {
     var _this = this;
+
     _classCallCheck(this, Producer);
 
     if (__DEV__) {
@@ -69,24 +71,20 @@ var Producer = (function () {
     });
   }
 
-  _prototypeProperties(Producer, null, {
+  _createClass(Producer, {
     set: {
       value: function set() {
         // intercept set to make it chainable
         this._ctx.set.apply(this._ctx, arguments);
         return this;
-      },
-      writable: true,
-      configurable: true
+      }
     },
     apply: {
       value: function apply() {
         // intercept apply to make it chainable
         this._ctx.apply.apply(this._ctx, arguments);
         return this;
-      },
-      writable: true,
-      configurable: true
+      }
     }
   });
 
@@ -98,6 +96,7 @@ var Remutable = (function () {
     var data = arguments[0] === undefined ? {} : arguments[0];
     var version = arguments[1] === undefined ? 0 : arguments[1];
     var hash = arguments[2] === undefined ? null : arguments[2];
+
     _classCallCheck(this, Remutable);
 
     hash = hash || Remutable.hashFn(Remutable.signFn(data));
@@ -123,68 +122,41 @@ var Remutable = (function () {
       json: null };
   }
 
-  _prototypeProperties(Remutable, {
-    fromJS: {
-      value: function fromJS(_ref) {
-        var h = _ref.h;
-        var v = _ref.v;
-        var d = _ref.d;
-        return new Remutable(d, v, h);
-      },
-      writable: true,
-      configurable: true
-    },
-    fromJSON: {
-      value: function fromJSON(json) {
-        return Remutable.fromJS(JSON.parse(json));
-      },
-      writable: true,
-      configurable: true
-    }
-  }, {
+  _createClass(Remutable, {
     dirty: {
       get: function () {
         return this._dirty;
-      },
-      configurable: true
+      }
     },
     hash: {
       get: function () {
         return this._hash;
-      },
-      configurable: true
+      }
     },
     version: {
       get: function () {
         return this._version;
-      },
-      configurable: true
+      }
     },
     head: {
       get: function () {
         return this._head;
-      },
-      configurable: true
+      }
     },
     working: {
       get: function () {
         return this._working;
-      },
-      configurable: true
+      }
     },
     createConsumer: {
       value: function createConsumer() {
         return new Consumer(this);
-      },
-      writable: true,
-      configurable: true
+      }
     },
     createProducer: {
       value: function createProducer() {
         return new Producer(this);
-      },
-      writable: true,
-      configurable: true
+      }
     },
     destroy: {
       value: function destroy() {
@@ -194,9 +166,7 @@ var Remutable = (function () {
         this._dirty = null;
         this._mutations = null;
         this._serialized = null;
-      },
-      writable: true,
-      configurable: true
+      }
     },
     toJS: {
       value: function toJS() {
@@ -209,9 +179,7 @@ var Remutable = (function () {
               d: this._head.toJS() } };
         }
         return this._js.js;
-      },
-      writable: true,
-      configurable: true
+      }
     },
     toJSON: {
       value: function toJSON() {
@@ -221,16 +189,12 @@ var Remutable = (function () {
             json: JSON.stringify(this.toJS()) };
         }
         return this._json.json;
-      },
-      writable: true,
-      configurable: true
+      }
     },
     get: {
       value: function get(key) {
         return this._working.get(key);
-      },
-      writable: true,
-      configurable: true
+      }
     },
     set: {
       value: function set(key, val) {
@@ -246,16 +210,12 @@ var Remutable = (function () {
           this._working = this._working.set(key, val);
         }
         return this;
-      },
-      writable: true,
-      configurable: true
+      }
     },
     "delete": {
       value: function _delete(key) {
         return this.set(key, void 0);
-      },
-      writable: true,
-      configurable: true
+      }
     },
     commit: {
       value: function commit() {
@@ -270,9 +230,7 @@ var Remutable = (function () {
         this._hash = patch.to.h;
         this._version = patch.to.v;
         return patch;
-      },
-      writable: true,
-      configurable: true
+      }
     },
     rollback: {
       value: function rollback() {
@@ -280,9 +238,7 @@ var Remutable = (function () {
         this._mutations = {};
         this._dirty = false;
         return this;
-      },
-      writable: true,
-      configurable: true
+      }
     },
     match: {
       value: function match(patch) {
@@ -290,9 +246,7 @@ var Remutable = (function () {
           patch.should.be.an.instanceOf(Remutable.Patch);
         }
         return this._hash === patch.from.h;
-      },
-      writable: true,
-      configurable: true
+      }
     },
     apply: {
       value: function apply(patch) {
@@ -301,6 +255,7 @@ var Remutable = (function () {
         var head = this._head.withMutations(function (map) {
           Object.keys(patch.mutations).forEach(function (key) {
             var t = patch.mutations[key].t;
+
             if (t === void 0) {
               map = map["delete"](key);
             } else {
@@ -313,9 +268,22 @@ var Remutable = (function () {
         this._hash = patch.to.h;
         this._version = patch.to.v;
         return this;
-      },
-      writable: true,
-      configurable: true
+      }
+    }
+  }, {
+    fromJS: {
+      value: function fromJS(_ref) {
+        var h = _ref.h;
+        var v = _ref.v;
+        var d = _ref.d;
+
+        return new Remutable(d, v, h);
+      }
+    },
+    fromJSON: {
+      value: function fromJSON(json) {
+        return Remutable.fromJS(JSON.parse(json));
+      }
     }
   });
 

--- a/dist/test.js
+++ b/dist/test.js
@@ -15,7 +15,6 @@ if (__DEV__) {
 var Remutable = require("../");
 var Patch = Remutable.Patch;
 
-
 var robert = "Robert Heinlein";
 var isaac = "Isaac Asimov";
 var dan = "Dan Simmons";
@@ -69,11 +68,22 @@ userListCopy.apply(patchCopy);
 userListCopy.head.get("3").should.be.exactly(dan);
 
 // It's possible to implement an undo stack by reverting patches
-var revert = Patch.revert(patch);
-userListCopy.apply(revert);
-userListCopy.head.has("3").should.be.exactly(false);
-userListCopy.head.contains(dan).should.be.exactly(false);
-userListCopy.head.contains(isaac).should.be.exactly(true);
+userListCopy.set("4", bard);
+var patch1 = userListCopy.commit();
+userListCopy.set("5", manu);
+var patch2 = userListCopy.commit();
+userListCopy.head.has("5").should.be.exactly(true);
+userListCopy.head.contains(manu).should.be.exactly(true);
+var revert2 = Patch.revert(patch2);
+userListCopy.apply(revert2);
+userListCopy.head.has("4").should.be.exactly(true);
+userListCopy.head.has("5").should.be.exactly(false);
+userListCopy.head.contains(bard).should.be.exactly(true);
+userListCopy.head.contains(manu).should.be.exactly(false);
+var revert1 = Patch.revert(patch1);
+userListCopy.apply(revert1);
+userListCopy.head.has("4").should.be.exactly(false);
+userListCopy.head.contains(bard).should.be.exactly(false);
 
 // Several small patches can be combined into a bigger one
 var userListCopy2 = Remutable.fromJSON(userList.toJSON());

--- a/src/Patch.js
+++ b/src/Patch.js
@@ -55,7 +55,11 @@ module.exports = function(Remutable) {
         const { f, t } = patch.mutations[key];
         mutations[key] = { f: t, t: f };
       });
-      return Patch.fromMutations({ mutations, hash: patch.to.h, version: patch.to.v });
+      return new Patch({
+        mutations,
+        from: { h: patch.to.h,    v: patch.to.v },
+        to:   { h: patch.from.h,  v: patch.from.v }
+      });
     }
 
     static fromMutations({ mutations, hash, version }) {

--- a/src/test.js
+++ b/src/test.js
@@ -54,11 +54,22 @@ userListCopy.apply(patchCopy);
 userListCopy.head.get('3').should.be.exactly(dan);
 
 // It's possible to implement an undo stack by reverting patches
-const revert = Patch.revert(patch);
-userListCopy.apply(revert);
-userListCopy.head.has('3').should.be.exactly(false);
-userListCopy.head.contains(dan).should.be.exactly(false);
-userListCopy.head.contains(isaac).should.be.exactly(true);
+userListCopy.set('4', bard);
+const patch1 = userListCopy.commit();
+userListCopy.set('5', manu);
+const patch2 = userListCopy.commit();
+userListCopy.head.has('5').should.be.exactly(true);
+userListCopy.head.contains(manu).should.be.exactly(true);
+const revert2 = Patch.revert(patch2);
+userListCopy.apply(revert2);
+userListCopy.head.has('4').should.be.exactly(true);
+userListCopy.head.has('5').should.be.exactly(false);
+userListCopy.head.contains(bard).should.be.exactly(true);
+userListCopy.head.contains(manu).should.be.exactly(false);
+const revert1 = Patch.revert(patch1);
+userListCopy.apply(revert1);
+userListCopy.head.has('4').should.be.exactly(false);
+userListCopy.head.contains(bard).should.be.exactly(false);
 
 // Several small patches can be combined into a bigger one
 const userListCopy2 = Remutable.fromJSON(userList.toJSON());


### PR DESCRIPTION
Found that an "Undo Stack" could only run 1 time. Trying to run it 2 or more times, or any Redo stack, would fail.

The `Patch.revert()` method calls `Patch.formMutations()` on it's
last line. `formMutations()` always gives a NEW hash and version,
never letting you go back into history.

My changes in this Commit and Pull Request fixes `revert()` to
let you go backwards in time with Hash/Version numbers.

Also, Rebuilt after changes, and updated Tests and Docs.

(Run `test.js` from this new commit against an older version of
Remutable to see the error in action).

FYI @elierotenberg thanks!