### PR TITLE
make it so you can combine patch that change the same properties

### DIFF
--- a/src/Patch.js
+++ b/src/Patch.js
@@ -104,8 +104,10 @@ export default(Remutable) => {
         // One can only combine compatible patches
         patchA.target.should.be.exactly(patchB.source);
       }
+      const mutations = _.clone(patchA.mutations);
+      _.extend(mutations.values.t, patchB.mutations.values.t);
       return new Patch({
-        mutations: _.extend(_.clone(patchA.mutations), patchB.mutations),
+        mutations,
         from: _.clone(patchA.from),
         to: _.clone(patchB.to),
       });


### PR DESCRIPTION
I was working on making an undo stack and I needed to combine patch that operate on the same properties. Using the old combine the change in the new patch would overwrite the old patch mutations.

So here is a proposed changed to allow combine to merge patches which change the same properties.
